### PR TITLE
feat: display toggleable role cards in grid

### DIFF
--- a/client/src/App.module.css
+++ b/client/src/App.module.css
@@ -122,11 +122,13 @@
   flex-direction: column;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.75rem;
+  padding: 0.75rem 0.5rem;
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid #555;
   border-radius: 0.5rem;
   box-sizing: border-box;
+  cursor: pointer;
+  transition: transform 0.2s ease, opacity 0.2s ease;
 }
 
 .rolePlaceholder {
@@ -141,6 +143,8 @@
   font-weight: bold;
   color: rgba(255, 255, 255, 0.4);
   font-family: "Spectral", serif;
+  transition: transform 0.2s ease;
+  overflow: hidden;
 }
 
 .roleName {
@@ -149,4 +153,22 @@
   color: #f5f5f5;
   text-align: center;
   font-family: "Spectral", serif;
+}
+
+.roleCardActive {
+  border: 2px solid #667eea;
+  box-shadow: 0 0 4px rgba(102, 126, 234, 0.8), 0 0 8px rgba(118, 75, 162, 0.5);
+}
+
+.roleCardInactive {
+  opacity: 0.4;
+  border: 1px solid #333;
+}
+
+.roleCard:hover .rolePlaceholder {
+  transform: scale(1.05);
+}
+
+.roleCard.roleCardInactive:hover {
+  opacity: 1;
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,7 @@ function App() {
   const [error, setError] = useState<string | null>(null);
   const [lobby, setLobby] = useState<LobbyState | null>(null);
   const [socket, setSocket] = useState<Socket | null>(null);
+  const [localSelectedRoles, setLocalSelectedRoles] = useState<string[]>([]);
 
   useEffect(() => {
     const sdkSetup = async () => {
@@ -38,6 +39,12 @@ function App() {
     console.log("Socket:", socket);
   }, []);
 
+  useEffect(() => {
+    if (lobby?.selectedRoles) {
+      setLocalSelectedRoles(lobby.selectedRoles);
+    }
+  }, [lobby?.selectedRoles]);
+
   if (isLoading) {
     return <div className={styles.container}>Loading...</div>;
   }
@@ -48,6 +55,18 @@ function App() {
 
   const playerCount = lobby?.players.length ?? 0;
   const maxPlayers = 5;
+
+  const handleToggleRole = (roleId: string) => {
+    setLocalSelectedRoles((prev) => {
+      if (prev.includes(roleId)) {
+        return prev.filter((id) => id !== roleId);
+      } else {
+        return [...prev, roleId];
+      }
+    });
+
+    socket?.emit("toggle_role", { roleId });
+  };
 
   return (
     <div className={styles.container}>
@@ -86,7 +105,16 @@ function App() {
         <h2 className={styles.rolesHeader}>Select Roles</h2>
         <div className={styles.rolesGrid}>
           {lobby?.availableRoles?.map((role) => (
-            <div key={role.id} className={styles.roleCard}>
+            <div
+              key={role.id}
+              className={`${styles.roleCard} ${
+                localSelectedRoles.includes(role.id)
+                  ? styles.roleCardActive
+                  : styles.roleCardInactive
+              }`}
+              data-testid="role-card"
+              onClick={() => handleToggleRole(role.id)}
+            >
               <div
                 className={styles.rolePlaceholder}
                 data-testid="role-placeholder"


### PR DESCRIPTION
#21 #22 
- Display all available roles using grid layout
- Show role name and focused background if on; unfocused if off
- Apply a consistent visual style for all cards
- When clicking a card, toggle its active/inactive state