### PR TITLE
feat: add role validation state to lobby state

### DIFF
--- a/client/src/discordSetup.ts
+++ b/client/src/discordSetup.ts
@@ -21,6 +21,7 @@ export interface LobbyState {
   players: Player[];
   availableRoles: Role[];
   selectedRoles: string[];
+  isRoleConfigValid: boolean;
 }
 
 let auth: Auth;


### PR DESCRIPTION
#25 
- After each toggle update, compute whether selectedRoles.length === playerCount + 3
- Store a boolean field such as isRoleConfigValid in the lobby state
- After validation, broadcast isRoleConfigValid and selectedRoles to all clients
- Ensure all clients stay synchronized with backend truth