### PR TITLE
feat: implement night phase transition

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,5 @@
 import styles from "./App.module.css";
+import { NightView } from "./components/game/NightView";
 import { RoleAssignmentView } from "./components/game/RoleAssignmentView";
 import { LobbyView } from "./components/lobby/LobbyView";
 import { useLobby } from "./hooks/useLobby";
@@ -26,6 +27,10 @@ function App() {
 
   if (lobby.gamePhase === "role_assignment") {
     return <RoleAssignmentView socket={socket} />;
+  }
+
+  if (lobby.gamePhase === "night") {
+    return <NightView socket={socket} />;
   }
 
   return null;

--- a/client/src/components/game/NightView.module.css
+++ b/client/src/components/game/NightView.module.css
@@ -1,0 +1,10 @@
+.container {
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background-color: #000;
+}

--- a/client/src/components/game/NightView.tsx
+++ b/client/src/components/game/NightView.tsx
@@ -1,0 +1,15 @@
+import { Socket } from "socket.io-client";
+import styles from "./NightView.module.css";
+
+interface NightViewProps {
+  socket: Socket | null;
+}
+
+export function NightView({ socket }: NightViewProps) {
+  console.log(socket);
+  return (
+    <div className={styles.container}>
+      <h1>Night View</h1>
+    </div>
+  );
+}

--- a/server/src/services/GameService.ts
+++ b/server/src/services/GameService.ts
@@ -1,4 +1,5 @@
 import { GameState, LobbyState, PlayerGameState } from "../types/lobby.types";
+import { allPlayersReady, resetPlayersReadiness } from "../utils/playerState";
 
 export class GameService {
   private games: Map<string, GameState> = new Map();
@@ -13,6 +14,7 @@ export class GameService {
   }
 
   createGame(lobby: LobbyState): GameState {
+    resetPlayersReadiness(lobby);
     const shuffledRoles = this.shuffleArray(lobby.selectedRoles);
 
     const playerRoles = new Map<string, PlayerGameState>();
@@ -46,5 +48,13 @@ export class GameService {
   ): PlayerGameState | undefined {
     const game = this.games.get(instanceId);
     return game?.playerRoles.get(userId);
+  }
+
+  startNight(lobby: LobbyState): boolean {
+    if (allPlayersReady(lobby) && lobby.gamePhase === "role_assignment") {
+      lobby.gamePhase = "night";
+      return true;
+    }
+    return false;
   }
 }

--- a/server/src/services/LobbyService.ts
+++ b/server/src/services/LobbyService.ts
@@ -5,6 +5,7 @@ import {
   Player,
   Role,
 } from "../types/lobby.types";
+import { allPlayersReady } from "../utils/playerState";
 
 export class LobbyService {
   private lobbies: Map<string, LobbyState> = new Map();
@@ -80,34 +81,17 @@ export class LobbyService {
     return lobby.selectedRoles.length === lobby.players.length + 3;
   }
 
-  resetPlayersReadiness(lobby: LobbyState): void {
-    lobby.players.forEach((player) => {
-      player.isReady = false;
-    });
-  }
-
-  allPlayersReady(lobby: LobbyState): boolean {
-    if (lobby.players.length === 0) return false;
-    return lobby.players.every((p) => p.isReady === true);
-  }
-
   isValidPlayerCount(lobby: LobbyState): boolean {
     return (
       lobby.players.length >= MIN_PLAYERS && lobby.players.length <= MAX_PLAYERS
     );
   }
 
-  setPlayerReady(lobby: LobbyState, userId: string): Player | undefined {
-    const player = lobby.players.find((p) => p.userId === userId);
-    if (player) {
-      player.isReady = true;
-    }
-    return player;
-  }
-
-  startGame(lobby: LobbyState): void {
-    if (this.allPlayersReady(lobby) && lobby.gamePhase === "lobby") {
+  startGame(lobby: LobbyState): boolean {
+    if (allPlayersReady(lobby) && lobby.gamePhase === "lobby") {
       lobby.gamePhase = "role_assignment";
+      return true;
     }
+    return false;
   }
 }

--- a/server/src/utils/playerState.ts
+++ b/server/src/utils/playerState.ts
@@ -1,0 +1,23 @@
+import { LobbyState, Player } from "../types/lobby.types";
+
+export function setPlayerReady(
+  lobby: LobbyState,
+  userId: string
+): Player | undefined {
+  const player = lobby.players.find((p) => p.userId === userId);
+  if (player) {
+    player.isReady = true;
+  }
+  return player;
+}
+
+export function allPlayersReady(lobby: LobbyState): boolean {
+  if (lobby.players.length === 0) return false;
+  return lobby.players.every((p) => p.isReady === true);
+}
+
+export function resetPlayersReadiness(lobby: LobbyState): void {
+  lobby.players.forEach((player) => {
+    player.isReady = false;
+  });
+}


### PR DESCRIPTION
#50 #48 
- Accept a player_ready message from the frontend
- Update the player's isReady = true in the lobby state
- After each ready update, check if all players have isReady === true
- If all players are ready, transition lobby state to phase: "night"
- Listen for backend broadcast containing phase: "night"
- Hide role reveal UI
- Automatically transition to the Night Phase screen